### PR TITLE
Remove allow-hosts

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -17,10 +17,6 @@ parts +=
       jenkins-test
       coverage
 
-allow-hosts +=
-      code.google.com
-      robotframework.googlecode.com
-
 extensions =
     mr.developer
 


### PR DESCRIPTION
allow-hosts was empty, so specifying allow-hosts += actually set it to a limited amount of hosts. This prevented robotframework from being installed. (Thanks to @pbauer).
